### PR TITLE
Patches required for linkstone

### DIFF
--- a/Paper-API-Patches/0014-Allow-transforming-plugin-classes.patch
+++ b/Paper-API-Patches/0014-Allow-transforming-plugin-classes.patch
@@ -1,0 +1,83 @@
+From 0941c97556e790ba9f701f1369e094a7d834ae77 Mon Sep 17 00:00:00 2001
+From: aki_ks <aki@kaysubs.de>
+Date: Tue, 3 Jul 2018 18:09:25 +0200
+Subject: [PATCH] Allow transforming plugin classes
+
+
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+index 1ea695d5..97330544 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+@@ -45,7 +45,7 @@ import org.yaml.snakeyaml.error.YAMLException;
+ /**
+  * Represents a Java plugin loader, allowing plugins in the form of .jar
+  */
+-public final class JavaPluginLoader implements PluginLoader {
++public class JavaPluginLoader implements PluginLoader {
+     final Server server;
+     private final Pattern[] fileFilters = new Pattern[] { Pattern.compile("\\.jar$"), };
+     private final Map<String, Class<?>> classes = new java.util.concurrent.ConcurrentHashMap<String, Class<?>>(); // Spigot
+@@ -124,7 +124,7 @@ public final class JavaPluginLoader implements PluginLoader {
+ 
+         final PluginClassLoader loader;
+         try {
+-            loader = new PluginClassLoader(this, getClass().getClassLoader(), description, dataFolder, file);
++            loader = newPluginLoader(this, getClass().getClassLoader(), description, dataFolder, file);
+         } catch (InvalidPluginException ex) {
+             throw ex;
+         } catch (Throwable ex) {
+@@ -136,6 +136,10 @@ public final class JavaPluginLoader implements PluginLoader {
+         return loader.plugin;
+     }
+ 
++    protected PluginClassLoader newPluginLoader(JavaPluginLoader loader, ClassLoader parent, PluginDescriptionFile description, File dataFolder, File file) throws Exception {
++        return new PluginClassLoader(loader, parent, description, dataFolder, file);
++    }
++
+     public PluginDescriptionFile getPluginDescription(File file) throws InvalidDescriptionException {
+         Validate.notNull(file, "File cannot be null");
+ 
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index bd936d9f..84a40825 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -23,7 +23,7 @@ import org.bukkit.plugin.PluginDescriptionFile;
+ /**
+  * A ClassLoader for plugins, to allow shared classes across multiple plugins
+  */
+-public final class PluginClassLoader extends URLClassLoader { // Spigot
++public class PluginClassLoader extends URLClassLoader { // Spigot
+     public JavaPlugin getPlugin() { return plugin; } // Spigot
+     private final JavaPluginLoader loader;
+     private final Map<String, Class<?>> classes = new java.util.concurrent.ConcurrentHashMap<String, Class<?>>(); // Spigot
+@@ -62,7 +62,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+     }
+     // Spigot End
+ 
+-    PluginClassLoader(final JavaPluginLoader loader, final ClassLoader parent, final PluginDescriptionFile description, final File dataFolder, final File file) throws IOException, InvalidPluginException, MalformedURLException {
++    public PluginClassLoader(final JavaPluginLoader loader, final ClassLoader parent, final PluginDescriptionFile description, final File dataFolder, final File file) throws IOException, InvalidPluginException, MalformedURLException {
+         super(new URL[] {file.toURI().toURL()}, parent);
+         Validate.notNull(loader, "Loader cannot be null");
+ 
+@@ -149,6 +149,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+                     CodeSigner[] signers = entry.getCodeSigners();
+                     CodeSource source = new CodeSource(url, signers);
+ 
++                    classBytes = transformBytecode(classBytes);
+                     result = defineClass(name, classBytes, 0, classBytes.length, source);
+                 }
+ 
+@@ -167,6 +168,10 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+         return result;
+     }
+ 
++    protected byte[] transformBytecode(byte[] bytecode) {
++        return bytecode;
++    }
++
+     @Override
+     public void close() throws IOException {
+         try {
+-- 
+2.18.0
+

--- a/Paper-API-Patches/0015-Allow-declaring-nms-classes.patch
+++ b/Paper-API-Patches/0015-Allow-declaring-nms-classes.patch
@@ -1,0 +1,23 @@
+From f61008d6c324b676b6566e1b487d774d0c08e06f Mon Sep 17 00:00:00 2001
+From: aki_ks <aki@kaysubs.de>
+Date: Wed, 4 Jul 2018 15:59:22 +0200
+Subject: [PATCH] Allow declaring nms classes
+
+
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index 84a40825..fdf89113 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -105,9 +105,6 @@ public class PluginClassLoader extends URLClassLoader { // Spigot
+     }
+ 
+     Class<?> findClass(String name, boolean checkGlobal) throws ClassNotFoundException {
+-        if (name.startsWith("org.bukkit.") || name.startsWith("net.minecraft.")) {
+-            throw new ClassNotFoundException(name);
+-        }
+         Class<?> result = classes.get(name);
+ 
+         if (result == null) {
+-- 
+2.18.0
+


### PR DESCRIPTION
These patches are necessary for the runtime support of linkstone.
- Glowstone must be able to transform plugin classes before they are loaded
- Plugins must be allowed to contains NMS and OBC classes or linkstone could be installed as a plugin.